### PR TITLE
Don't bail on USB interface busy

### DIFF
--- a/src/picousb.rs
+++ b/src/picousb.rs
@@ -279,9 +279,9 @@ impl<T: UsbContext> PicobootConnection<T> {
                     _ => false,
                 };
 
-                handle
-                    .set_active_configuration(cfg)
-                    .expect("could not configure handle");
+                if !handle.set_active_configuration(cfg).is_ok() {
+                    println!("Warning: could not set USB active configuration");
+                }
                 handle
                     .claim_interface(iface)
                     .expect("could not claim interface");


### PR DESCRIPTION
Not sure why, but on my system (Ubuntu 24.04 LTS) the call to set_active_configuration causes the system to bail with "Busy".

```
Running `target/debug/usb_picoboot_rs`
thread 'main' panicked at src/picousb.rs:284:22:
could not configure handle: Busy
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Replacing it with a warning makes the flash process succeed.
I'm not happy with not knowing why this works, but it could just be a quirk of rusb + libusb version.
I'd rather replace rusb with nusb than try to work it out.